### PR TITLE
Add support for the Action command

### DIFF
--- a/schema/schema.v0.json
+++ b/schema/schema.v0.json
@@ -68,6 +68,9 @@
             "items": {
                 "oneOf": [
                     {
+                        "$ref": "#/$defs/Commands/Action"
+                    },
+                    {
                         "$ref": "#/$defs/Commands/AddMedia"
                     },
                     {
@@ -347,6 +350,27 @@
             ]
         },
         "Commands": {
+            "Action": {
+                "title": "action",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "action"
+                ],
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "description": "The action to be performed",
+                        "enum": [
+                            "back",
+                            "clearKeychain",
+                            "hideKeyboard",
+                            "pasteText",
+                            "scroll"
+                        ]
+                    }
+                }
+            },
             "AddMedia": {
                 "title": "addMedia",
                 "type": "object",

--- a/tests/examples/extreme.yaml
+++ b/tests/examples/extreme.yaml
@@ -14,6 +14,12 @@ onFlowComplete:
   - runFlow: teardown.yaml
   - runScript: teardown.js
 ---
+- action: 'back'
+- action: 'hideKeyboard'
+- action: 'scroll'
+- action: 'clearKeychain'
+- action: 'pasteText'
+
 - addMedia:
     - "./assets/foo.png"
     - "./assets/foo.mp4"


### PR DESCRIPTION
Had a look through [DDG's flows](https://github.com/duckduckgo/Android/tree/develop/.maestro) and spotted that they were using a rarely used (and undocumented?) version of the single-word commands, wrapped as action, e.g. 
```
- action: 'back'
```