### PR TITLE
Schema fixes

### DIFF
--- a/schema/schema.v0.json
+++ b/schema/schema.v0.json
@@ -984,120 +984,24 @@
                 ],
                 "properties": {
                     "copyTextFrom": {
-                        "oneOf": [
+                        "description": "Command to tap on a view, specified using text, ID, point, or other detailed selectors.",
+                        "$ref": "#/$defs/Element",
+                        "examples": [
                             {
-                                "type": "string",
-                                "description": "Copy text from an element identified via its text (or regular expression)",
-                                "minLength": 1
+                                "id": "title-bar"
                             },
                             {
-                                "type": "object",
-                                "description": "Command to tap on a view, specified using text, ID, point, or other detailed selectors.",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "text": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified text. Supports regular expressions."
-                                    },
-                                    "id": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified accessibility ID. Supports regular expressions."
-                                    },
-                                    "index": {
-                                        "type": "number",
-                                        "minimum": 0,
-                                        "description": "0-based index to specify which element to select among similar matches."
-                                    },
-                                    "width": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified width."
-                                    },
-                                    "height": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified height."
-                                    },
-                                    "tolerance": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "description": "Tolerance to apply when comparing width and height."
-                                    },
-                                    "enabled": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified enabled state."
-                                    },
-                                    "checked": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified checked state."
-                                    },
-                                    "focused": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified focused state."
-                                    },
-                                    "selected": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified selected state."
-                                    },
-                                    "below": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is below another element with the specified text."
-                                    },
-                                    "above": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is above another element."
-                                    },
-                                    "leftOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the left of another element with the specified text."
-                                    },
-                                    "rightOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the right of another element with the specified text."
-                                    },
-                                    "containsChild": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that contains a child with the specified text."
-                                    },
-                                    "point": {
-                                        "description": "Point on the screen to tap on, either relative or absolute.",
-                                        "type": "string",
-                                        "pattern": "^(\\d+%,\\s?\\d+%)|(\\d+,\\s?\\d+)$"
-                                    },
-                                    "containsDescendants": {
-                                        "description": "Matches an element that has all the specified descendant elements.",
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/$defs/Element"
-                                        }
-                                    },
-                                    "label": {
-                                        "title": "copyTextFrom.label",
-                                        "type": "string",
-                                        "description": "Description of the action to be performed."
-                                    },
-                                    "optional": {
-                                        "title": "copyTextFrom.optional",
-                                        "type": "boolean",
-                                        "description": "Indicates if the action is optional."
-                                    }
-                                },
-                                "examples": [
-                                    {
-                                        "id": "title-bar"
-                                    },
-                                    {
-                                        "id": "login-button",
-                                        "enabled": true
-                                    },
-                                    {
-                                        "text": ".*£.*",
-                                        "below": {
-                                            "text": "Subtotal"
-                                        }
-                                    }
-                                ]
+                                "id": "login-button",
+                                "enabled": true
+                            },
+                            {
+                                "text": ".*£.*",
+                                "below": {
+                                    "text": "Subtotal"
+                                }
                             }
                         ]
-                    }
+            }
                 }
             },
             "ClipboardPasteText": {
@@ -2831,137 +2735,21 @@
                 ],
                 "properties": {
                     "tapOn": {
-                        "oneOf": [
+                        "description": "Command to tap on a view, specified using text, ID, point, or other detailed selectors.",
+                        "$ref": "#/$defs/Element",
+                        "examples": [
                             {
-                                "type": "string",
-                                "description": "Tap on an element identified via its text",
-                                "minLength": 1
+                                "text": "Submit"
                             },
                             {
-                                "type": "object",
-                                "description": "Command to tap on a view, specified using text, ID, point, or other detailed selectors.",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "text": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified text. Supports regular expressions."
-                                    },
-                                    "id": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified accessibility ID. Supports regular expressions."
-                                    },
-                                    "index": {
-                                        "type": "number",
-                                        "minimum": 0,
-                                        "description": "0-based index to specify which element to select among similar matches."
-                                    },
-                                    "width": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified width."
-                                    },
-                                    "height": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified height."
-                                    },
-                                    "tolerance": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "description": "Tolerance to apply when comparing width and height."
-                                    },
-                                    "enabled": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified enabled state."
-                                    },
-                                    "checked": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified checked state."
-                                    },
-                                    "focused": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified focused state."
-                                    },
-                                    "selected": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified selected state."
-                                    },
-                                    "retryTapIfNoChange": {
-                                        "type": "boolean",
-                                        "default": true,
-                                        "description": "Determines whether to retry the tap if no hierarchy change is detected."
-                                    },
-                                    "below": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is below another element with the specified text."
-                                    },
-                                    "above": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is above another element."
-                                    },
-                                    "leftOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the left of another element with the specified text."
-                                    },
-                                    "rightOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the right of another element with the specified text."
-                                    },
-                                    "containsChild": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that contains a child with the specified text."
-                                    },
-                                    "point": {
-                                        "description": "Point on the screen to tap on, either relative or absolute.",
-                                        "type": "string",
-                                        "pattern": "^(\\d+%,\\s?\\d+%)|(\\d+,\\s?\\d+)$"
-                                    },
-                                    "containsDescendants": {
-                                        "description": "Matches an element that has all the specified descendant elements.",
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/$defs/Element"
-                                        }
-                                    },
-                                    "repeat": {
-                                        "type": "number",
-                                        "minimum": 1,
-                                        "description": "Number of times to repeat the tap action."
-                                    },
-                                    "delay": {
-                                        "type": "number",
-                                        "minimum": 0,
-                                        "description": "Delay in milliseconds between repeated taps. Default is 100ms."
-                                    },
-                                    "waitToSettleTimeoutMs": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "description": "Time in milliseconds to wait for the screen to settle after the tap."
-                                    },
-                                    "label": {
-                                        "title": "tapOn.label",
-                                        "type": "string",
-                                        "description": "Description of the action to be performed."
-                                    },
-                                    "optional": {
-                                        "title": "tapOn.optional",
-                                        "type": "boolean",
-                                        "description": "Indicates if the action is optional."
-                                    }
-                                },
-                                "examples": [
-                                    {
-                                        "text": "Submit"
-                                    },
-                                    {
-                                        "id": "login-button",
-                                        "enabled": true
-                                    },
-                                    {
-                                        "text": "Next",
-                                        "below": {
-                                            "text": "Terms and Conditions"
-                                        }
-                                    }
-                                ]
+                                "id": "login-button",
+                                "enabled": true
+                            },
+                            {
+                                "text": "Next",
+                                "below": {
+                                    "text": "Terms and Conditions"
+                                }
                             }
                         ]
                     }
@@ -2975,138 +2763,22 @@
                     "doubleTapOn"
                 ],
                 "properties": {
-                    "doubleTapOn": {
-                        "oneOf": [
+                    "doubleTapOn": {   
+                        "description": "Double tap on an element, specified using text, ID, point, or detailed selectors.",
+                        "$ref": "#/$defs/Element",
+                        "examples": [
                             {
-                                "type": "string",
-                                "description": "Double tap on an element, identified via its text",
-                                "minLength": 1
+                                "text": "Submit"
                             },
                             {
-                                "type": "object",
-                                "description": "Double tap on an element, specified using text, ID, point, or detailed selectors.",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "text": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified text. Supports regular expressions."
-                                    },
-                                    "id": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified accessibility ID. Supports regular expressions."
-                                    },
-                                    "index": {
-                                        "type": "number",
-                                        "minimum": 0,
-                                        "description": "0-based index to specify which element to select among similar matches."
-                                    },
-                                    "width": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified width."
-                                    },
-                                    "height": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified height."
-                                    },
-                                    "tolerance": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "description": "Tolerance to apply when comparing width and height."
-                                    },
-                                    "enabled": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified enabled state."
-                                    },
-                                    "checked": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified checked state."
-                                    },
-                                    "focused": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified focused state."
-                                    },
-                                    "selected": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified selected state."
-                                    },
-                                    "retryTapIfNoChange": {
-                                        "type": "boolean",
-                                        "default": true,
-                                        "description": "Determines whether to retry the tap if no hierarchy change is detected."
-                                    },
-                                    "below": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is below another element with the specified text."
-                                    },
-                                    "above": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is above another element."
-                                    },
-                                    "leftOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the left of another element with the specified text."
-                                    },
-                                    "rightOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the right of another element with the specified text."
-                                    },
-                                    "containsChild": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that contains a child with the specified text."
-                                    },
-                                    "point": {
-                                        "description": "Point on the screen to tap on, either relative or absolute.",
-                                        "type": "string",
-                                        "pattern": "^(\\d+%,\\s?\\d+%)|(\\d+,\\s?\\d+)$"
-                                    },
-                                    "containsDescendants": {
-                                        "description": "Matches an element that has all the specified descendant elements.",
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/$defs/Element"
-                                        }
-                                    },
-                                    "repeat": {
-                                        "type": "number",
-                                        "minimum": 1,
-                                        "description": "Number of times to repeat the tap action."
-                                    },
-                                    "delay": {
-                                        "type": "number",
-                                        "minimum": 0,
-                                        "description": "Delay in milliseconds between repeated taps. Default is 100ms."
-                                    },
-                                    "waitToSettleTimeoutMs": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "description": "Time in milliseconds to wait for the screen to settle after the tap."
-                                    },
-                                    "label": {
-                                        "title": "doubleTapOn.label",
-                                        "type": "string",
-                                        "description": "Description of the action to be performed."
-                                    },
-                                    "optional": {
-                                        "title": "doubleTapOn.optional",
-                                        "type": "boolean",
-                                        "description": "Indicates if the action is optional."
-                                    }
-                                },
-                                "examples": [
-                                    {
-                                        "text": "Submit"
-                                    },
-                                    {
-                                        "id": "login-button",
-                                        "enabled": true
-                                    },
-                                    {
-                                        "text": "Next",
-                                        "below": {
-                                            "text": "Terms and Conditions"
-                                        }
-                                    }
-                                ]
+                                "id": "login-button",
+                                "enabled": true
+                            },
+                            {
+                                "text": "Next",
+                                "below": {
+                                    "text": "Terms and Conditions"
+                                }
                             }
                         ]
                     }
@@ -3121,137 +2793,21 @@
                 ],
                 "properties": {
                     "longPressOn": {
-                        "oneOf": [
+                        "description": "Long press on an element, specified using text, ID, point, or detailed selectors.",
+                        "$ref": "#/$defs/Element",
+                        "examples": [
                             {
-                                "type": "string",
-                                "description": "Long press on an element, identified via its text",
-                                "minLength": 1
+                                "text": "Submit"
                             },
                             {
-                                "type": "object",
-                                "description": "Long press on an element, specified using text, ID, point, or detailed selectors.",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "text": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified text. Supports regular expressions."
-                                    },
-                                    "id": {
-                                        "type": "string",
-                                        "description": "Matches element with the specified accessibility ID. Supports regular expressions."
-                                    },
-                                    "index": {
-                                        "type": "number",
-                                        "minimum": 0,
-                                        "description": "0-based index to specify which element to select among similar matches."
-                                    },
-                                    "width": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified width."
-                                    },
-                                    "height": {
-                                        "type": "integer",
-                                        "description": "Matches element with the specified height."
-                                    },
-                                    "tolerance": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "description": "Tolerance to apply when comparing width and height."
-                                    },
-                                    "enabled": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified enabled state."
-                                    },
-                                    "checked": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified checked state."
-                                    },
-                                    "focused": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified focused state."
-                                    },
-                                    "selected": {
-                                        "type": "boolean",
-                                        "description": "Matches element with the specified selected state."
-                                    },
-                                    "retryTapIfNoChange": {
-                                        "type": "boolean",
-                                        "default": true,
-                                        "description": "Determines whether to retry the tap if no hierarchy change is detected."
-                                    },
-                                    "below": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is below another element with the specified text."
-                                    },
-                                    "above": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that is above another element."
-                                    },
-                                    "leftOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the left of another element with the specified text."
-                                    },
-                                    "rightOf": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element to the right of another element with the specified text."
-                                    },
-                                    "containsChild": {
-                                        "$ref": "#/$defs/Element",
-                                        "description": "Matches an element that contains a child with the specified text."
-                                    },
-                                    "point": {
-                                        "description": "Point on the screen to tap on, either relative or absolute.",
-                                        "type": "string",
-                                        "pattern": "^(\\d+%,\\s?\\d+%)|(\\d+,\\s?\\d+)$"
-                                    },
-                                    "containsDescendants": {
-                                        "description": "Matches an element that has all the specified descendant elements.",
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/$defs/Element"
-                                        }
-                                    },
-                                    "repeat": {
-                                        "type": "number",
-                                        "minimum": 1,
-                                        "description": "Number of times to repeat the tap action."
-                                    },
-                                    "delay": {
-                                        "type": "number",
-                                        "minimum": 0,
-                                        "description": "Delay in milliseconds between repeated taps. Default is 100ms."
-                                    },
-                                    "waitToSettleTimeoutMs": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "description": "Time in milliseconds to wait for the screen to settle after the tap."
-                                    },
-                                    "label": {
-                                        "title": "longTapOn.label",
-                                        "type": "string",
-                                        "description": "Description of the action to be performed."
-                                    },
-                                    "optional": {
-                                        "title": "longTapOn.optional",
-                                        "type": "boolean",
-                                        "description": "Indicates if the action is optional."
-                                    }
-                                },
-                                "examples": [
-                                    {
-                                        "text": "Submit"
-                                    },
-                                    {
-                                        "id": "login-button",
-                                        "enabled": true
-                                    },
-                                    {
-                                        "text": "Next",
-                                        "below": {
-                                            "text": "Terms and Conditions"
-                                        }
-                                    }
-                                ]
+                                "id": "login-button",
+                                "enabled": true
+                            },
+                            {
+                                "text": "Next",
+                                "below": {
+                                    "text": "Terms and Conditions"
+                                }
                             }
                         ]
                     }

--- a/schema/schema.v0.json
+++ b/schema/schema.v0.json
@@ -286,6 +286,74 @@
                     "type": "boolean",
                     "title": "If set to true, test won't fail if view can't be found",
                     "default": false
+                },
+                "above": {
+                    "$ref": "#/$defs/Element",
+                    "title": "The element we're looking for is above the one described by this element"
+                },
+                "below": {
+                    "$ref": "#/$defs/Element",
+                    "title": "The element we're looking for is below the one described by this element"
+                },
+                "leftOf": {
+                    "$ref": "#/$defs/Element",
+                    "title": "The element we're looking for is to the left of the one described by this element"
+                },
+                "rightOf": {
+                    "$ref": "#/$defs/Element",
+                    "title": "The element we're looking for is to the right of the one described by this element"
+                },
+                "containsChild": {
+                    "$ref": "#/$defs/Element",
+                    "title": "The element we're looking for contains the one described by this element"
+                },
+                "containsDescendants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Element"
+                    },
+                    "title": "The element we're looking for contains all the elements described by this array, somewhere in the element tree"
+                },
+                "childOf": {
+                    "$ref": "#/$defs/Element",
+                    "title": "The element we're looking for is a child of the one described by this element"
+                },
+                "point": {
+                    "description": "Point on the screen to tap on, either relative or absolute.",
+                    "type": "string",
+                    "pattern": "^(\\d+%,\\s?\\d+%)|(\\d+,\\s?\\d+)$"
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Description of the action to be performed. Used in console output."
+                },
+                "repeat": {
+                    "type": "integer",
+                    "description": "Number of times to repeat a tap",
+                    "minimum": 0
+                },
+                "delay": {
+                    "type": "integer",
+                    "description": "Delay in milliseconds between repeats",
+                    "minimum": 0
+                },
+                "traits": {
+                    "type": "string",
+                    "description": "Space separated list of traits. Can be text, long-text, or square",
+                    "$comment": "Tighter validation would need to be an enum of all 15 possible combinations of 1/2/3 of these traits"
+                },
+                "waitUntilVisible": {
+                    "type": "boolean",
+                    "description": "Wait until the element is visible before performing the tap"
+                },
+                "retryTapIfNoChange": {
+                    "type": "boolean",
+                    "description": "Retry the tap if the screen doesn't change after the tap"
+                },
+                "waitToSettleTimeoutMs": {
+                    "type": "integer",
+                    "description": "Time in milliseconds to wait for the screen to settle after the action",
+                    "minimum": 0
                 }
             }
         },

--- a/schema/schema.v0.json
+++ b/schema/schema.v0.json
@@ -251,8 +251,11 @@
                     "title": "Finds id that matches regexp"
                 },
                 "index": {
-                    "type": "number",
-                    "title": "0-based index of the view to select among those that match all other criteria"
+                    "type": [
+                        "string",
+                        "number"
+                    ],
+                    "title": "0-based index of the view to select among those that match all other criteria. Can also be a JavaScript expression."
                 },
                 "width": {
                     "type": "number",

--- a/schema/schema.v0.json
+++ b/schema/schema.v0.json
@@ -1286,14 +1286,12 @@
                         "oneOf": [
                             {
                                 "required": [
-                                    "visible",
-                                    "timeout"
+                                    "visible"
                                 ]
                             },
                             {
                                 "required": [
-                                    "notVisible",
-                                    "timeout"
+                                    "notVisible"
                                 ]
                             }
                         ],

--- a/tests/examples/extreme.yaml
+++ b/tests/examples/extreme.yaml
@@ -80,6 +80,12 @@ onFlowComplete:
     label: 'Wipe the data'
     optional: true
 
+- copyTextFrom: '.*Total.*'
+- copyTextFrom:
+    text: '\d+'
+    label: 'Copy the total'
+    optional: false
+
 - eraseText
 - eraseText: 3
 - eraseText:

--- a/tests/examples/extreme.yaml
+++ b/tests/examples/extreme.yaml
@@ -206,6 +206,24 @@ onFlowComplete:
       - tapOn:
           id: 'fabAddIcon'
 
+- repeat:
+    while:
+      visible:
+        text: 'Some Text'
+        containsChild:
+          id: 'someChild'
+        containsDescendants:
+          - id: 'someDescendant1'
+          - text: 'someDescendant2'
+            below:
+              id: 'someDescendant1'
+          - id: 'someDescendant3'
+        childOf:
+          id: 'someParent'
+    commands:
+      - tapOn:
+          id: 'fabAddIcon'
+
 - retry:
     maxRetries: 3
     commands:
@@ -371,6 +389,15 @@ onFlowComplete:
 - tapOn:
     text: "A text with a hyperlink"
     point: "90%,50%"
+- tapOn:
+    id: "someId"
+    repeat: 3
+    delay: 100
+    traits: 'square'
+    waitUntilVisible: true
+    retryTapIfNoChange: false
+    waitToSettleTimeoutMs: 500
+    label: 'Tap a square thing thrice when it appears'
 
 - longPressOn: Text
 - longPressOn:

--- a/tests/examples/extreme.yaml
+++ b/tests/examples/extreme.yaml
@@ -398,6 +398,9 @@ onFlowComplete:
     retryTapIfNoChange: false
     waitToSettleTimeoutMs: 500
     label: 'Tap a square thing thrice when it appears'
+- tapOn:
+    text: 'Add to Basket'
+    index: ${output.index}
 
 - longPressOn: Text
 - longPressOn:


### PR DESCRIPTION
- Fixes and unifies our representation of elements, and adds a bunch of missing props. It introduces some oddities, like allowing point or retryTapIfNoChange to things like copyText. But Maestro allows these too.
- Fixes index on element selectors - this was a hard integer, but actually should accept JavaScript. Maestro represents it as a string, but I've kept the number for better validation.
- Removed timeout from being required for `extendedWaitUntil` - it's got an internal default