### PR TITLE
feat: add clickable file path navigation in YAML files

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
         "command": "maestroWorkbench.listDevices",
         "title": "List Available Devices",
         "icon": "$(device-desktop)"
+      },
+      {
+        "command": "maestroWorkbench.openYamlFile",
+        "title": "Open YAML File"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { globalState } from './state/state';
 import { checkYamlExtension, getFilePatterns, getOrCreateTerminal, updateYamlSchemaAssociations } from './utils/utils';
 import { watchTestFiles, discoverTests, registerTestProfiles } from './testExplorer/testExplorer';
 import { getAvailableDevices } from './utils/device';
+import { registerYamlPathOpener } from './utils/yamlPathOpener';
 
 let deviceOutputChannel: vscode.OutputChannel;
 
@@ -36,6 +37,7 @@ export function activate(context: vscode.ExtensionContext) {
 	registerTestProfiles(controller);
 	promptForRating(context);
 	updateFileWatcherAndTreeView(controller, context);
+	registerYamlPathOpener(context);
 
 	vscode.workspace.onDidChangeConfiguration((e) => {
 		if (e.affectsConfiguration('maestroWorkbench.filePatterns')) {

--- a/src/utils/yamlPathOpener.ts
+++ b/src/utils/yamlPathOpener.ts
@@ -1,0 +1,147 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const YAML_FILE_EXTENSIONS = ['.yaml', '.yml'];
+const JS_FILE_EXTENSIONS = ['.js'];
+
+/**
+ * Creates a new regex instance for matching file paths in quoted strings.
+ * Must create a new instance each time to avoid global regex state issues.
+ * @returns A new RegExp instance matching YAML and JS file paths in quotes
+ */
+export function createFilePathRegex(): RegExp {
+    return /["']([^\s"':]*\.(?:ya?ml|js))["']/gi;
+}
+
+/**
+ * Registers a command and document link provider to open YAML and JS files
+ * referenced within YAML documents.
+ * @param context - The extension context for managing subscriptions
+ */
+export function registerYamlPathOpener(context: vscode.ExtensionContext) {
+    const openFileCommand = vscode.commands.registerCommand('maestroWorkbench.openYamlFile', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showErrorMessage('No active editor found.');
+            return;
+        }
+
+        let selectedText = editor.document.getText(editor.selection);
+        if (!selectedText) {
+            const line = editor.document.lineAt(editor.selection.active.line);
+            const match = createFilePathRegex().exec(line.text);
+            if (match?.[1]) {
+                selectedText = match[1];
+            }
+        }
+
+        if (!selectedText) {
+            vscode.window.showErrorMessage('No text selected or found in the current line.');
+            return;
+        }
+
+        const cleanPath = selectedText.trim();
+        await openYamlFile(editor.document.uri, cleanPath);
+    });
+
+    const documentLinkProvider: vscode.DocumentLinkProvider = {
+        provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
+            const links: vscode.DocumentLink[] = [];
+
+            for (let lineNum = 0; lineNum < document.lineCount; lineNum++) {
+                
+                if (lineNum % 100 === 0 && token.isCancellationRequested) {
+                    return [];
+                }
+
+                const line = document.lineAt(lineNum);
+                const regex = createFilePathRegex();
+                let match;
+
+                while ((match = regex.exec(line.text)) !== null) {
+                    const linkPath = match[1];
+                    const startPos = new vscode.Position(lineNum, match.index);
+                    const endPos = new vscode.Position(lineNum, match.index + match[0].length);
+                    const range = new vscode.Range(startPos, endPos);
+
+                    const targetUri = resolvePathUri(document.uri, linkPath);
+                    if (targetUri) {
+                        links.push(new vscode.DocumentLink(range, targetUri));
+                    }
+                }
+            }
+
+            return links;
+        }
+    };
+
+    context.subscriptions.push(vscode.languages.registerDocumentLinkProvider({ language: 'yaml', scheme: 'file' }, documentLinkProvider));
+    context.subscriptions.push(openFileCommand);
+}
+
+/**
+ * Opens a YAML or JS file in the editor.
+ * @param baseUri - The URI of the current document (for resolving relative paths)
+ * @param filePath - The file path to open (can be relative or absolute)
+ */
+async function openYamlFile(baseUri: vscode.Uri, filePath: string): Promise<void> {
+    const hasValidExtension = [...YAML_FILE_EXTENSIONS, ...JS_FILE_EXTENSIONS].some(ext =>
+        filePath.toLowerCase().endsWith(ext)
+    );
+
+    if (!hasValidExtension) {
+        vscode.window.showErrorMessage(
+            `Invalid file type: ${filePath} (expected .yaml, .yml, or .js)`
+        );
+        return;
+    }
+
+    try {
+        const targetUri = resolvePathUri(baseUri, filePath);
+        if (!targetUri) {
+            vscode.window.showErrorMessage(`File not found or not accessible: ${filePath}`);
+            return;
+        }
+
+        const document = await vscode.workspace.openTextDocument(targetUri);
+        await vscode.window.showTextDocument(document);
+    } catch (error) {
+        vscode.window.showErrorMessage(
+            `Failed opening file: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
+    }
+}
+
+/**
+ * Resolves a file path to a URI, checking if the file exists.
+ * @param baseUri - The URI of the current document (for resolving relative paths)
+ * @param filePath - The file path to resolve (can be relative or absolute)
+ * @returns The resolved URI if the file exists and is valid, null otherwise
+ */
+export function resolvePathUri(baseUri: vscode.Uri, filePath: string): vscode.Uri | null { 
+    const hasYamlExtension = YAML_FILE_EXTENSIONS.some(ext =>
+        filePath.toLowerCase().endsWith(ext)
+    );
+    const hasJsExtension = JS_FILE_EXTENSIONS.some(ext =>
+        filePath.toLowerCase().endsWith(ext)
+    );
+
+    if (!hasYamlExtension && !hasJsExtension) {
+        return null;
+    }
+
+    const absolutePath = path.isAbsolute(filePath)
+        ? filePath
+        : path.join(path.dirname(baseUri.fsPath), filePath);
+
+    try {
+        if (fs.existsSync(absolutePath) && fs.lstatSync(absolutePath).isFile()) {
+            return vscode.Uri.file(absolutePath);
+        }
+    } catch (error) {
+        return null;
+    }
+
+    return null;
+}


### PR DESCRIPTION
This PR adds clickable file path navigation to improve workflow and experience when working with large Maestro test suites. Users can now Cmd+Click (or Ctrl+Click) on file paths in YAML files to instantly open referenced flows and scripts.

## Purpose
When working with large Maestro test suites containing dozens of flows, developers frequently need to navigate between files referenced in YAML configurations. For example, when a flow uses `runFlow` or `runScript` to reference another file:


  ``` yaml
  - runFlow: "flows/authentication/login.yaml"
  - runScript: "../../scripts/setup-test-data.js"
  - runFlow: "../shared/common-steps.yml"
```

  Previously, developers had to:
  1. Manually copy the file path
  2. Use "Go to File" or file explorer to search
  3. Navigate through nested directories

  This becomes tedious and time-consuming in large test suites with complex directory structures.

  This PR solves that by making file paths clickable. Now Maestro users can:
  - Cmd+Click (Mac) or Ctrl+Click (Windows/Linux) on any quoted file path to open it instantly
  - Use the "Open YAML File" command from the Command Palette as an alternative
  - Navigate quickly between related flows without leaving the editor
  
   Example Use Case

  In a test suite with this structure:
 ```
 maestro/
  ├── flows/
  │   ├── onboarding/
  │   │   ├── signup.yaml
  │   │   └── login.yaml
  │   └── checkout/
  │       └── purchase.yaml
  ├── shared/
  │   └── common-steps.yaml
  └── scripts/
      └── test-helpers.js
```

  When editing signup.yaml that references:
``` yaml
  - runFlow: "../shared/common-steps.yaml"
  - runScript: "../../scripts/test-helpers.js"
  - runFlow: "login.yaml"
```

  Developers can now click directly on any path to open the file, instead of manually navigating the file tree.

 ## Changes
 - Add registerYamlPathOpener function with DocumentLinkProvider
 - Implement automatic detection of file paths in quoted strings
 - Support .yaml, .yml, and .js file extensions
 - Handle relative paths (./, ../), nested paths, and absolute paths
 - Case-insensitive extension matching (supports .YAML, .YML, .JS)

 ## Testing
  - [x] Tested clicking on YAML file paths (e.g., `"flows/login.yaml"`)
  - [x] Tested clicking on JS script paths (e.g., `"../../data/auth.js"`)
  - [x] Verified parent directory navigation (`../`)
  - [x] Tested case-insensitive extensions (`.YAML`, `.YML`, `.JS`)

